### PR TITLE
add queries for generalized horizons which support yearly, monthly and daily auctions properly

### DIFF
--- a/jao/webservice.py
+++ b/jao/webservice.py
@@ -175,6 +175,10 @@ class JaoAPIClient:
                 m += relativedelta(months=1)
             elif horizon == "Yearly":
                 m += relativedelta(years=1)
+            elif horizon == "Intraday":
+                m += relativedelta(hours=1)
+            else:
+                m += relativedelta(days=7)
         df = pd.DataFrame(data)
         df['resoldCapacity'].astype(float).fillna(0, inplace=True)
         df['nonAllocatedCapacity'] = df['offeredCapacity'] - df['allocatedCapacity']

--- a/jao/webservice.py
+++ b/jao/webservice.py
@@ -54,7 +54,7 @@ class JaoAPIClient:
         elif horizon == 'Yearly':
             r = self.s.get(self.BASEURL + 'getauctions', params={
                 'corridor': corridor,
-                'fromdate': query_date.strftime("%Y-12-31"),
+                'fromdate': f"{query_date.year-1}-12-31",
                 'horizon': horizon,
                 'shadow': int(shadow_auctions_only)
             })
@@ -80,10 +80,9 @@ class JaoAPIClient:
 
         return data
 
-    def query_auction_details_by_month(self, corridor: str, query_date: date, shadow_auctions_only: bool = False) -> dict:
-        data = self.query_auction_details(corridor, query_date, "Monthly", shadow_auctions_only)
+    def query_auction_details_by_month(self, corridor: str, query_date: date, horizon="Monthly", shadow_auctions_only: bool = False) -> dict:
+        data = self.query_auction_details(corridor, query_date, horizon, shadow_auctions_only)
         return data
-
 
     def query_auction_bids_by_month(self, corridor: str, month: date, as_dict: bool = False) -> Union[pd.DataFrame, dict]:
         """

--- a/jao/webservice.py
+++ b/jao/webservice.py
@@ -40,6 +40,10 @@ class JaoAPIClient:
         """
         # prepare the specific input arguments needed, start day the day before the months begin
         # end date the last day of the month
+        
+        if horizon == 'Weekly':
+            # weekly must start on monday
+            query_date += relativedelta(weekday=0)
 
         if horizon == "Monthly":
             month_begin = query_date.replace(day=1)
@@ -72,11 +76,16 @@ class JaoAPIClient:
         r.raise_for_status()
 
         data = r.json()
-        # prettify the results to only show the first products and results
-        data = data[0]
-        data = {**data, **data['results'][0], **data['products'][0]}
-        del data['results']
-        del data['products']
+
+        try:
+            # prettify the results to only show the first products and results
+            data = data[0]
+            data = {**data, **data['results'][0], **data['products'][0]}
+            del data['results']
+            del data['products']
+        except Exception:
+            print(data)
+            raise
 
         return data
 
@@ -168,7 +177,7 @@ class JaoAPIClient:
             data.append(m_data)
 
             if horizon == "Weekly":
-                m += relativedelta(weeks=1)
+                m += relativedelta(weeks=1, weekday=1)
             elif horizon == "Daily":
                 m += relativedelta(days=1)
             elif horizon == "Monthly":

--- a/jao/webservice.py
+++ b/jao/webservice.py
@@ -28,7 +28,7 @@ class JaoAPIClient:
         r.raise_for_status()
         return [x['value'] for x in r.json()]
 
-    def query_auction_details_by_month(self, corridor: str, month: date, horizon: str, shadow_auctions_only: bool = False) -> dict:
+    def query_auction_details(self, corridor: str, query_date: date, horizon: str, shadow_auctions_only: bool = False) -> dict:
         """
         get the auction data for a specified month. gives basically everything but the bids themselves
 
@@ -41,16 +41,9 @@ class JaoAPIClient:
         # prepare the specific input arguments needed, start day the day before the months begin
         # end date the last day of the month
 
-        month_begin = month.replace(day=1)
-        month_end = month.replace(day=monthrange(month.year, month.month)[1])
-        if horizon == 'Yearly':
-            r = self.s.get(self.BASEURL + 'getauctions', params={
-                'corridor': corridor,
-                'fromdate': month.strftime('%Y-%m-%d'),
-                'horizon': horizon,
-                'shadow': int(shadow_auctions_only)
-            })
-        else:
+        if horizon == "Monthly":
+            month_begin = query_date.replace(day=1)
+            month_end = query_date.replace(day=monthrange(query_date.year, query_date.month)[1])
             r = self.s.get(self.BASEURL + 'getauctions', params={
                 'corridor': corridor,
                 'fromdate': (month_begin - timedelta(days=1)).strftime("%Y-%m-%d"),
@@ -58,17 +51,39 @@ class JaoAPIClient:
                 'todate': month_end.strftime("%Y-%m-%d"),
                 'shadow': int(shadow_auctions_only)
             })
+        elif horizon == 'Yearly':
+            r = self.s.get(self.BASEURL + 'getauctions', params={
+                'corridor': corridor,
+                'fromdate': query_date.strftime("%Y-12-31"),
+                'horizon': horizon,
+                'shadow': int(shadow_auctions_only)
+            })
+        else:
+            r = self.s.get(self.BASEURL + 'getauctions', params={
+                'corridor': corridor,
+                'fromdate': query_date.strftime("%Y-%m-%d-%H:%M:%S"),
+                'horizon': horizon,
+                'shadow': int(shadow_auctions_only)
+            })
 
+        # improves error feedback a lot
+        if r.status_code >= 400 and not r.reason:
+            r.reason = r.text
         r.raise_for_status()
 
         data = r.json()
-        # pretify the results since we know it is for monthly auction
+        # prettify the results to only show the first products and results
         data = data[0]
         data = {**data, **data['results'][0], **data['products'][0]}
         del data['results']
         del data['products']
 
         return data
+
+    def query_auction_details_by_month(self, corridor: str, query_date: date, shadow_auctions_only: bool = False) -> dict:
+        data = self.query_auction_details(corridor, query_date, "Monthly", shadow_auctions_only)
+        return data
+
 
     def query_auction_bids_by_month(self, corridor: str, month: date, as_dict: bool = False) -> Union[pd.DataFrame, dict]:
         """
@@ -115,7 +130,7 @@ class JaoAPIClient:
         else:
             return pd.DataFrame(r.json())
 
-    def query_auction_stats_months(self, month_from: date, month_to: date, corridor: str, horizon: str = 'Monthly') -> pd.DataFrame:
+    def query_auction_stats(self, date_from: date, date_to: date, corridor: str, horizon: str = 'Monthly') -> pd.DataFrame:
         """
         gets the following statistics for the give range of months (included both ends) in a dataframe:
         id
@@ -142,19 +157,32 @@ class JaoAPIClient:
                         'allocatedCapacity', 'resoldCapacity', 'requestedCapacity', 'auctionPrice']
 
         data = []
-        m = month_from
-        while m <= month_to:
-            m_details = self.query_auction_details_by_month(corridor=corridor, month=m, horizon=horizon)
+        m = date_from
+        while m <= date_to:
+            m_details = self.query_auction_details(corridor=corridor, query_date=m, horizon=horizon)
             m_data = {
                 'id': m_details['identification'],
                 'corridor': corridor,
-                'month': m.replace(day=1)
+                'date': m
             }
             m_data = {**m_data, **{k: v for k, v in m_details.items() if k in detail_keys}}
             data.append(m_data)
-            m += relativedelta(months=1)
+
+            if horizon == "Weekly":
+                m += relativedelta(weeks=1)
+            elif horizon == "Daily":
+                m += relativedelta(days=1)
+            elif horizon == "Monthly":
+                m += relativedelta(months=1)
+            elif horizon == "Yearly":
+                m += relativedelta(years=1)
         df = pd.DataFrame(data)
-        df['resoldCapacity'].fillna(0, inplace=True)
+        df['resoldCapacity'].astype(float).fillna(0, inplace=True)
         df['nonAllocatedCapacity'] = df['offeredCapacity'] - df['allocatedCapacity']
 
         return df
+
+    def query_auction_stats_months(self, month_from: date, month_to: date, corridor: str, horizon: str = 'Monthly') -> pd.DataFrame:
+        month_from = month_from.replace(day=1)
+
+        return self.query_auction_stats(month_from, month_to, corridor, horizon)


### PR DESCRIPTION
This project did not correctly handle queries to daily horizon, as the day was always set to 1 (as needed for the month queries).
By introducing two new functions: 

`query_auction_details` and `query_auction_stats`  this is now properly handled and can be extended (I did not find corridors which have other horizons than the named available).

The previous monthly queries are mapped to call the generalized functions, to not break existing code.