### PR TITLE
Added TSO filtering for domain queries

### DIFF
--- a/test_core_flowbased.py
+++ b/test_core_flowbased.py
@@ -38,6 +38,34 @@ def test_initial_domain(client, mtu):
     assert len(df) == 12430
 
 
+def test_domains_with_tso(client, mtu):
+    # Via TSO alias
+    df = client.query_initial_domain(
+        mtu=mtu,
+        tso="TRANSNETBW",
+    )
+    assert len(df["tso"].unique()) == 1
+    assert len(df) == 139
+
+    # Via TSO EIC
+    df = client.query_prefinal_domain(
+        mtu=mtu,
+        presolved=True,
+        tso="10XDE-EON-NETZ-C",
+    )
+    assert len(df["tso"].unique()) == 1
+    assert len(df) == 4
+
+    # Multiple TSOs
+    df = client.query_final_domain(
+        mtu=mtu,
+        presolved=True,
+        tso=["TENNETBV", "10XDE-EON-NETZ-C"],
+    )
+    assert len(df["tso"].unique()) == 2
+    assert len(df) == 12
+
+
 def test_allocationconstraint(client, mtu):
     df = client.query_allocationconstraint(
         d_from=mtu,


### PR DESCRIPTION
This PR addes the option to filter for one or more TSOs when querying domains (initial, prefinal and final). 

The existing functions `query_initial_domain`, `query_prefinal_domain` and `query_final_domain` had some redundant code. I moved this into the `_query_domain` function.

This PR is **marked as draft** because I'm unsure how you manage version numbers with `__version__`.